### PR TITLE
Fix no signing and BOM creation for large payloads

### DIFF
--- a/pkg-core/src/main/java/com/github/gino0631/pkg/ProductBuilder.java
+++ b/pkg-core/src/main/java/com/github/gino0631/pkg/ProductBuilder.java
@@ -235,7 +235,9 @@ public final class ProductBuilder {
 
         // Build XAR
         try (XarBuilder xarBuilder = XarBuilder.getInstance()) {
-            xarBuilder.setSigning(signingPrivateKey, signingCertificates, signingProvider, signingTsa);
+            if (signingPrivateKey != null && signingCertificates != null) {
+                xarBuilder.setSigning(signingPrivateKey, signingCertificates, signingProvider, signingTsa);
+            }
 
             Files.walkFileTree(flatDir, new SimpleFileVisitor<Path>() {
                 Deque<XarBuilder.Container> xarPath = new LinkedList<>();

--- a/pkg-core/src/main/java/com/github/gino0631/pkg/jbomutils/MkBom.java
+++ b/pkg-core/src/main/java/com/github/gino0631/pkg/jbomutils/MkBom.java
@@ -66,7 +66,7 @@ public class MkBom {
                 n.gid = Integer.parseInt(elements[2]);
                 n.size = 0;
                 n.checksum = 0;
-                //n.linkNameLength = 0;              
+                //n.linkNameLength = 0;
                 if ((n.mode & 0xF000) == 0x4000) {
                     n.type = TNodeType.KDirectoryNode;
                     n.linkName = "";
@@ -241,6 +241,7 @@ public class MkBom {
             }
 
             if (num_paths > 1) {
+                root_paths.indices.add(new BomPathIndices());
                 root_paths.indices.get(current_path).index0 = (new BomPaths(Tools.getBIS(bom.getBlock(last_paths_id)))).forward = bom.addBlock(Tools.getBytes(paths), current_path_size);
                 root_paths.indices.get(current_path).index1 = last_file_info;
                 tree.child = bom.addBlock(Tools.getBytes(root_paths), path_size);


### PR DESCRIPTION
Hi.

When trying to use your plugin, we've met a couple of problems. I've made 2 small fixes that seem to resolve these issues.

The first is that a ```NullPointerException``` is thrown if no signing is configured, since the signing code is called regardless. The second is that a ```ArrayOutOfBoundsException``` is thrown during BOM creation if there are more than 255 entries because of a bug in the loop that builds the BOM.

This should fix #1.